### PR TITLE
Fix ini example

### DIFF
--- a/src/examples/ini.md
+++ b/src/examples/ini.md
@@ -20,6 +20,7 @@ document_root=/var/www/example.org
 document_root=/var/www/example.com
 ip=
 interface=eth1
+
 ```
 
 Each line contains a **key and value** separated by an equals sign; or contains

--- a/src/examples/ini.md
+++ b/src/examples/ini.md
@@ -56,12 +56,18 @@ more characters, `char+`; and the latter consist of zero or more characters,
 name = { char+ }
 value = { char* }
 ```
+These two must be separated by an  `=` sign that can be surrounded by an arbitrary 
+number of whitespaces. 
+
+```pest
+sep = { " "* ~ "=" ~ " "* }
+```
 
 Now it's easy to express the two kinds of input lines.
 
 ```pest
 section = { "[" ~ name ~ "]" }
-property = { name ~ "=" ~ value }
+property = { name ~ sep ~ value }
 ```
 
 Finally, we need a rule to represent an entire input file. The expression


### PR DESCRIPTION
-  Support white space around equal separator in INI files

  The grammar as it was failed to support white space around name=value
    entries in an INI file. I faced these errors:

```
    thread 'main' panicked at 'unsuccessful parse: Error { variant: ParsingError { positives: [char], negatives: [] }, location: Pos(8), line_col: Pos((1, 9)), path: None, line: "username = noha␊", continued_line: None }', src/libcore/result.rs:997:5
```

- Finish file with new line

    As it stands the current grammar does not parse the given file
    correctly. Not sure how to fix it in the grammar otherwise I
    would.

```
    thread 'main' panicked at 'unsuccessful parse: Error { variant: ParsingError { positives: [char], negatives: [] }, location: Pos(223), line_col: Pos((15, 17)), path: None, line: "interface = eth1", continued_line: None }', src/libcore/result.rs:997:5
```



