### PR TITLE
Added some config options

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -2,6 +2,16 @@
 title = "A thoughtful introduction to the pest parser"
 description = "An introduction to the pest parser by implementing a Rust grammar subset"
 author = "Dragoș Tiselice"
+language = "en"
+multilingual = false
 
 [output.html]
+git-repository-url = "https://github.com/pest-parser/book/tree/master/"
+edit-url-template = "https://github.com/pest-parser/book/edit/master/{path}"
 additional-js = ["highlight-pest.js"]
+
+[output.html.playground]
+runnable = false
+
+[output.html.print]
+enable = false


### PR DESCRIPTION
Mostly opened this because `output.html.playground` is enabled by default but the code snippets are not written with this in mind so there's a `run` button that just crashes on most if not all snippets 😅.

Since I made this, I added a few more that may or may not feel useful to you, feel free to let me know if you want some of these reverted.

## Additions

- `langauge` and `multilingual, I believe these are the defaults anyway but added them regardless
- `git-repository-url` and `edit-url-template` these add two buttons on the top right that are handy for viewing the source of each page
- `runnable = false` disables the Rust playground integration in code cells
- `[output.html.print] enable = false` disables the printing option