### PR TITLE
2021 edition migration

### DIFF
--- a/examples/calculator/Cargo.toml
+++ b/examples/calculator/Cargo.toml
@@ -2,6 +2,8 @@
 name = "calculator"
 version = "0.1.0"
 authors = ["wirelyre <wirelyre@gmail.com>"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 lazy_static = "1.1"

--- a/examples/calculator/Cargo.toml
+++ b/examples/calculator/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "calculator"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["wirelyre <wirelyre@gmail.com>"]
 edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
 lazy_static = "1.1"
-pest = "2.0"
-pest_derive = "2.0"
+pest = "2.6.0"
+pest_derive = "2.6.0"

--- a/examples/calculator/Cargo.toml
+++ b/examples/calculator/Cargo.toml
@@ -7,5 +7,5 @@ rust-version = "1.56"
 
 [dependencies]
 lazy_static = "1.1"
-pest = "2.6.0"
-pest_derive = "2.6.0"
+pest = "2.6"
+pest_derive = "2.6"

--- a/examples/calculator/src/main.rs
+++ b/examples/calculator/src/main.rs
@@ -1,12 +1,10 @@
-#[macro_use]
-extern crate lazy_static;
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
+use lazy_static::lazy_static;
+use pest_derive::Parser;
+use pest::Parser;
+
 
 use pest::iterators::Pairs;
 use pest::pratt_parser::{Assoc, Op, PrattParser};
-use pest::Parser;
 use std::io::BufRead;
 
 #[derive(Parser)]

--- a/examples/csv-tool/Cargo.toml
+++ b/examples/csv-tool/Cargo.toml
@@ -2,6 +2,8 @@
 name = "csv-tool"
 version = "0.1.0"
 authors = ["wirelyre <wirelyre@gmail.com>"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 pest = "2.0"

--- a/examples/csv-tool/Cargo.toml
+++ b/examples/csv-tool/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-pest = "2.6.0"
-pest_derive = "2.6.0"
+pest = "2.6"
+pest_derive = "2.6"

--- a/examples/csv-tool/Cargo.toml
+++ b/examples/csv-tool/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "csv-tool"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["wirelyre <wirelyre@gmail.com>"]
 edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-pest = "2.0"
-pest_derive = "2.0"
+pest = "2.6.0"
+pest_derive = "2.6.0"

--- a/examples/csv-tool/src/main.rs
+++ b/examples/csv-tool/src/main.rs
@@ -1,8 +1,5 @@
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
-
 use pest::Parser;
+use pest_derive::Parser;
 use std::fs;
 
 #[derive(Parser)]
@@ -14,7 +11,8 @@ fn main() {
 
     let file = CSVParser::parse(Rule::file, &unparsed_file)
         .expect("unsuccessful parse") // unwrap the parse result
-        .next().unwrap(); // get and unwrap the `file` rule; never fails
+        .next()
+        .unwrap(); // get and unwrap the `file` rule; never fails
 
     let mut field_sum: f64 = 0.0;
     let mut record_count: u64 = 0;

--- a/examples/ini-parser/Cargo.toml
+++ b/examples/ini-parser/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "ini-parser"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["wirelyre <wirelyre@gmail.com>"]
 edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-pest = "2.0"
-pest_derive = "2.0"
+pest = "2.6.0"
+pest_derive = "2.6.0"

--- a/examples/ini-parser/Cargo.toml
+++ b/examples/ini-parser/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ini-parser"
 version = "0.1.0"
 authors = ["wirelyre <wirelyre@gmail.com>"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 pest = "2.0"

--- a/examples/ini-parser/Cargo.toml
+++ b/examples/ini-parser/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-pest = "2.6.0"
-pest_derive = "2.6.0"
+pest = "2.6"
+pest_derive = "2.6"

--- a/examples/ini-parser/src/main.rs
+++ b/examples/ini-parser/src/main.rs
@@ -1,8 +1,5 @@
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
-
 use pest::Parser;
+use pest_derive::Parser;
 use std::collections::HashMap;
 use std::fs;
 
@@ -15,7 +12,8 @@ fn main() {
 
     let file = INIParser::parse(Rule::file, &unparsed_file)
         .expect("unsuccessful parse") // unwrap the parse result
-        .next().unwrap(); // get and unwrap the `file` rule; never fails
+        .next()
+        .unwrap(); // get and unwrap the `file` rule; never fails
 
     let mut properties: HashMap<&str, HashMap<&str, &str>> = HashMap::new();
     let mut current_section_name = "";

--- a/examples/jlang-parser/Cargo.toml
+++ b/examples/jlang-parser/Cargo.toml
@@ -2,7 +2,8 @@
 name = "jlang-parser"
 version = "0.1.0"
 authors = ["Matt Quinn <matt@mattjquinn.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 pest = "2.1.0"

--- a/examples/jlang-parser/Cargo.toml
+++ b/examples/jlang-parser/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-pest = "2.6.0"
-pest_derive = "2.6.0"
+pest = "2.6"
+pest_derive = "2.6"

--- a/examples/jlang-parser/Cargo.toml
+++ b/examples/jlang-parser/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "jlang-parser"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Matt Quinn <matt@mattjquinn.com>"]
 edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-pest = "2.1.0"
-pest_derive = "2.1.0"
+pest = "2.6.0"
+pest_derive = "2.6.0"

--- a/examples/jlang-parser/src/main.rs
+++ b/examples/jlang-parser/src/main.rs
@@ -1,10 +1,7 @@
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
-
 use self::AstNode::*;
 use pest::error::Error;
 use pest::Parser;
+use pest_derive::Parser;
 use std::ffi::CString;
 
 #[derive(Parser)]

--- a/examples/json-parser/Cargo.toml
+++ b/examples/json-parser/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-pest = "2.6.0"
-pest_derive = "2.6.0"
+pest = "2.6"
+pest_derive = "2.6"

--- a/examples/json-parser/Cargo.toml
+++ b/examples/json-parser/Cargo.toml
@@ -2,6 +2,8 @@
 name = "json-parser"
 version = "0.1.0"
 authors = ["wirelyre <wirelyre@gmail.com>"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 pest = "2.0"

--- a/examples/json-parser/Cargo.toml
+++ b/examples/json-parser/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "json-parser"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["wirelyre <wirelyre@gmail.com>"]
 edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-pest = "2.0"
-pest_derive = "2.0"
+pest = "2.6.0"
+pest_derive = "2.6.0"

--- a/examples/json-parser/src/main.rs
+++ b/examples/json-parser/src/main.rs
@@ -1,9 +1,6 @@
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
-
 use pest::error::Error;
 use pest::Parser;
+use pest_derive::Parser;
 use std::fs;
 
 #[derive(Parser)]

--- a/examples/pest-calculator/Cargo.toml
+++ b/examples/pest-calculator/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "pest-calculator"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pest = "2.4.0"
-pest_derive = "2.4.0"
 lazy_static = "1.4.0"
+pest = "2.6.0"
+pest_derive = "2.6.0"

--- a/examples/pest-calculator/Cargo.toml
+++ b/examples/pest-calculator/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 lazy_static = "1.4.0"
-pest = "2.6.0"
-pest_derive = "2.6.0"
+pest = "2.6"
+pest_derive = "2.6"

--- a/src/examples/csv.md
+++ b/src/examples/csv.md
@@ -31,8 +31,8 @@ Add the `pest` and `pest_derive` crates to the dependencies section in `Cargo.to
 
 ```toml
 [dependencies]
-pest = "2.0"
-pest_derive = "2.0"
+pest = "2.6"
+pest_derive = "2.6"
 ```
 
 ## Writing the parser

--- a/src/examples/csv.md
+++ b/src/examples/csv.md
@@ -35,17 +35,6 @@ pest = "2.0"
 pest_derive = "2.0"
 ```
 
-And finally bring `pest` and `pest_derive` into scope in `src/main.rs`:
-
-```rust
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
-```
-
-The `#[macro_use]` attribute is necessary to use `pest` to generate parsing
-code! This is a very important attribute.
-
 ## Writing the parser
 
 `pest` works by compiling a description of a file format, called a *grammar*,
@@ -64,6 +53,7 @@ Rust needs to know to compile this file using `pest`:
 
 ```rust
 use pest::Parser;
+use pest_derive::Parser;
 
 #[derive(Parser)]
 #[grammar = "csv.pest"]

--- a/src/examples/ini.md
+++ b/src/examples/ini.md
@@ -78,11 +78,8 @@ file = {
 To compile the parser into Rust, we need to add the following to `src/main.rs`:
 
 ```rust
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
-
 use pest::Parser;
+use pest_derive::Parser;
 
 #[derive(Parser)]
 #[grammar = "ini.pest"]

--- a/src/examples/json.md
+++ b/src/examples/json.md
@@ -171,11 +171,8 @@ json = _{ SOI ~ (object | array) ~ EOI }
 Let's compile the grammar into Rust.
 
 ```rust
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
-
 use pest::Parser;
+use pest_derive::Parser;
 
 #[derive(Parser)]
 #[grammar = "json.pest"]

--- a/src/examples/rust/setup.md
+++ b/src/examples/rust/setup.md
@@ -36,18 +36,14 @@ to be.
 [1]: https://docs.rs/pest/1.0/pest/trait.Parser.html
 
 ```rust
+// Don't forget to request use of the pest and pest_derive crate
+use pest::Parser;
+use pest_derive::Parser
+
 #[cfg(debug_assertions)]
 const _GRAMMAR: &'static str = include_str!("path/to/rust.pest"); // relative to this file
 
 #[derive(Parser)]
 #[grammar = "path/to/rust.pest"] // relative to src
 struct RustParser;
-```
-
-Also, don't forget to add the crate dependency in your crate's main file.
-
-```rust
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
 ```

--- a/src/examples/rust/setup.md
+++ b/src/examples/rust/setup.md
@@ -10,8 +10,8 @@ on [rustup.rs](https://rustup.rs). Once that is out of the way, make sure you
 add *pest* to your `Cargo.toml`:
 
 ```toml
-pest = "^1.0"
-pest_derive = "^1.0"
+pest = "2.6"
+pest_derive = "2.6"
 ```
 
 *pest_derive* is the part of the parser that analyzes, verifies, optimizes, and


### PR DESCRIPTION
Fixes #36
Changes:

- Removed  `extern crate` old syntax
- Set rust edition to 2021
- Updated minimal pest version to 2.6 both in the introduction and in the examples

I don't know if there is some document that tells what has to be done when pest updates are made, but if there is it should be considered to add *“update the examples in the book”* (if that is not already the case).