### PR TITLE
Completed pest grammar for a working example

### DIFF
--- a/src/examples/calculator.md
+++ b/src/examples/calculator.md
@@ -64,6 +64,16 @@ Corresponding to this format, we define our rule for expressions:
 ```pest
 expr = { atom ~ (bin_op ~ atom)* }
 ```
+
+And finally, we define our `WHITESPACE` and equation rule:
+```pest
+WHITESPACE = _{ " " }
+
+// We can't have SOI and EOI on expr directly, because it is used
+// recursively (e.g. with parentheses)
+equation = _{ SOI ~ expr ~ EOI }
+```
+
 This defines the grammar which generates the required input for the Pratt parser.
 
 ## Abstract Syntax Tree


### PR DESCRIPTION
I was following along the [tutorial](https://pest.rs/book/examples/calculator.html#pratt-parser) but I noticed that when I tried to run it would not work. It would error with:

```sh
error[E0599]: no variant or associated item named `equation` found for enum `Rule` in the current scope
  --> src\main.rs:45:45
   |
25 | #[derive(Parser)]
   |          ------ variant or associated item `equation` not found for this enum
...
45 |         match CalculatorParser::parse(Rule::equation, &line?) {
   |                                             ^^^^^^^^ variant or associated item not found in `Rule`
```

But when I went into [examples/pest-calculator/src/calculator.pest](https://github.com/pest-parser/book/blob/master/examples/pest-calculator/src/calculator.pest), I realized that there were two lines that were missing in the tutorial that were crucial to getting the examples to work. When I added:

```pest
equation = _{ SOI ~ expr ~ EOI }
WHITESPACE = _{ " " }
```

it was working as intended.

So I added the example in the book, though I'm not sure if it is is worded properly.