### PR TITLE
docs: add missing description for `ASCII`

### DIFF
--- a/src/grammars/built-ins.md
+++ b/src/grammars/built-ins.md
@@ -29,6 +29,7 @@ And for **miscellaneous** use:
 
 | Built-in rule        | Meaning              | Equivalent                              |
 |:--------------------:|:--------------------:|:---------------------------------------:|
+| `ASCII`              | any ascii character  | <code>'\u{00}'..'\u{7F}'</code>         |
 | `ASCII_ALPHANUMERIC` | any digit or letter  | <code>ASCII_DIGIT \| ASCII_ALPHA</code> |
 | `NEWLINE`            | any line feed format | <code>"\n" \| "\r\n" \| "\r"</code>     |
 


### PR DESCRIPTION
fixes pest-parser/pest#995

# Changes:
add description for built-in rule `ASCII`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new built-in grammar rule `ASCII` for representing any ASCII character in grammar definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->