### PR TITLE
Update ini example file to parse correctly.

### DIFF
--- a/src/examples/ini.md
+++ b/src/examples/ini.md
@@ -5,9 +5,9 @@ there is no standard for the format, we'll write a program that is able to
 parse this example file:
 
 ```ini
-username = noha
-password = plain_text
-salt = NaCl
+username=noha
+password=plain_text
+salt=NaCl
 
 [server_1]
 interface=eth0


### PR DESCRIPTION
Removed spaces around equals sign in example ini file.

The grammar doesn't take spaces into account, and when parsing it failed for me on those examples.

It would be possible to update the grammar to include `SPACE_SEPARATOR` in the right places, but I thought it would be better to leave the grammar and update the example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the INI file format example to enforce a stricter format by removing spaces around the equal sign, impacting how INI files are parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->