### PR TITLE
rename the author field to authors in book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,7 @@
 [book]
 title = "A thoughtful introduction to the pest parser"
 description = "An introduction to the pest parser by implementing a Rust grammar subset"
-author = "Dragoș Tiselice"
+authors = ["Dragoș Tiselice"]
 language = "en"
 multilingual = false
 


### PR DESCRIPTION
See the [mdbook documentation](https://rust-lang.github.io/mdBook/format/configuration/general.html)
Apparently the `author` was field was [incorrect documentation](https://github.com/rust-lang/mdBook/issues/2623)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced book metadata to support multiple authors, enabling future collaborative author entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->