### PR TITLE
Use `LazyLock` over `lazy_static`

### DIFF
--- a/examples/awk/Cargo.toml
+++ b/examples/awk/Cargo.toml
@@ -9,4 +9,3 @@ pest_derive = "2.8"
 clap = { version = "4", features = ["derive"] }
 regex = "1.5"
 anyhow = "1"
-lazy_static = "1.4"

--- a/examples/calculator/Cargo.toml
+++ b/examples/calculator/Cargo.toml
@@ -3,9 +3,7 @@ name = "calculator"
 version = "0.1.1"
 authors = ["wirelyre <wirelyre@gmail.com>"]
 edition = "2021"
-rust-version = "1.76"
 
 [dependencies]
-lazy_static = "1.4"
 pest = "2.7"
 pest_derive = "2.7"

--- a/examples/calculator/src/main.rs
+++ b/examples/calculator/src/main.rs
@@ -1,4 +1,3 @@
-use lazy_static::lazy_static;
 use pest_derive::Parser;
 use pest::Parser;
 
@@ -6,22 +5,21 @@ use pest::Parser;
 use pest::iterators::Pairs;
 use pest::pratt_parser::{Assoc, Op, PrattParser};
 use std::io::BufRead;
+use std::sync::LazyLock;
 
 #[derive(Parser)]
 #[grammar = "grammar.pest"]
 struct Calculator;
 
-lazy_static! {
-    static ref PRATT_PARSER: PrattParser<Rule> = {
-        use Rule::*;
-        use Assoc::*;
+static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
+    use Rule::*;
+    use Assoc::*;
 
-        PrattParser::new()
-            .op(Op::infix(add, Left) | Op::infix(subtract, Left))
-            .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
-            .op(Op::infix(power, Right))
-    };
-}
+    PrattParser::new()
+        .op(Op::infix(add, Left) | Op::infix(subtract, Left))
+        .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
+        .op(Op::infix(power, Right))
+});
 
 fn eval(expression: Pairs<Rule>) -> f64 {
     PRATT_PARSER

--- a/examples/json-parser/src/main.rs
+++ b/examples/json-parser/src/main.rs
@@ -38,7 +38,7 @@ fn serialize_jsonvalue(val: &JSONValue) -> String {
     }
 }
 
-fn parse_json_file(file: &str) -> Result<JSONValue, Error<Rule>> {
+fn parse_json_file(file: &str) -> Result<JSONValue<'_>, Error<Rule>> {
     use pest::iterators::Pair;
 
     let json = JSONParser::parse(Rule::json, file)?.next().unwrap();

--- a/examples/pest-calculator/Cargo.toml
+++ b/examples/pest-calculator/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1.4.0"
 pest = "2.6"
 pest_derive = "2.6"

--- a/examples/pest-calculator/src/main.rs
+++ b/examples/pest-calculator/src/main.rs
@@ -1,25 +1,23 @@
 use pest::iterators::Pairs;
 use pest::pratt_parser::PrattParser;
 use pest::Parser;
-use std::io::{self, BufRead};
+use std::{io::{self, BufRead}, sync::LazyLock};
 
 #[derive(pest_derive::Parser)]
 #[grammar = "calculator.pest"]
 pub struct CalculatorParser;
 
-lazy_static::lazy_static! {
-    static ref PRATT_PARSER: PrattParser<Rule> = {
-        use pest::pratt_parser::{Assoc::*, Op};
-        use Rule::*;
+static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
+    use pest::pratt_parser::{Assoc::*, Op};
+    use Rule::*;
 
-        // Precedence is defined lowest to highest
-        PrattParser::new()
-            // Addition and subtract have equal precedence
-            .op(Op::infix(add, Left) | Op::infix(subtract, Left))
-            .op(Op::infix(multiply, Left) | Op::infix(divide, Left) | Op::infix(modulo, Left))
-            .op(Op::prefix(unary_minus))
-    };
-}
+    // Precedence is defined lowest to highest
+    PrattParser::new()
+        // Addition and subtract have equal precedence
+        .op(Op::infix(add, Left) | Op::infix(subtract, Left))
+        .op(Op::infix(multiply, Left) | Op::infix(divide, Left) | Op::infix(modulo, Left))
+        .op(Op::prefix(unary_minus))
+});
 
 #[derive(Debug)]
 pub enum Expr {

--- a/src/intro.md
+++ b/src/intro.md
@@ -34,17 +34,15 @@ WHITESPACE = _{ " " | "\t" }
 And here is the function that uses that parser to calculate answers:
 
 ```rust
-lazy_static! {
-    static ref PRATT_PARSER: PrattParser<Rule> = {
-        use Rule::*;
-        use Assoc::*;
+static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
+    use Rule::*;
+    use Assoc::*;
 
-        PrattParser::new()
-            .op(Op::infix(add, Left) | Op::infix(subtract, Left))
-            .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
-            .op(Op::infix(power, Right))
-    };
-}
+    PrattParser::new()
+        .op(Op::infix(add, Left) | Op::infix(subtract, Left))
+        .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
+        .op(Op::infix(power, Right))
+});
 
 fn eval(expression: Pairs<Rule>) -> f64 {
     PRATT_PARSER


### PR DESCRIPTION
`lazy_static!` is out of date, and `LazyLock` (now in `std`) should be used instead. To avoid confusion for users that have never used `lazy_static!`, this PR changes the examples and any code blocks to use `LazyLock`s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Global parser initialization moved to std LazyLock across examples; runtime behavior unchanged.

* **Documentation**
  * Examples and guides updated to reflect the new initialization approach and clarified grammar (parentheses, unary minus, associativity).

* **Chores**
  * Removed legacy lazy_static dependency and adjusted manifest metadata.

* **Examples/API**
  * JSON parser example function signature updated to include a lifetime annotation (may affect example usage).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->